### PR TITLE
Make example almost useable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Below is an example configuration of your maven project to use this plugin:
   <plugin>
     <groupId>com.digitalbarista</groupId>
     <artifactId>getdown-maven-plugin</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.3</version>
     <configuration>
-      <!– A reference to a base getdown.txt file in your project –>
+      <!--A reference to a base getdown.txt file in your project-->
       <configFile>src/main/configs/getdown.txt</configFile>
-      <!– A list of additional properties that should appear in the getdown.txt –>
+      <!--A list of additional properties that should appear in the getdown.txt-->
       <configProps>
         <appbase>http://www.mycompany.com/software/myApp/
         <ui.name>My App - Play it and enjoy!</ui.name>
@@ -23,7 +23,7 @@ Below is an example configuration of your maven project to use this plugin:
         Set stripVersions to true if you want the versions removed from the jar
         file names, so that getdown does not leave a trail of jar versions behind
       -->
-      <stripVersions>false</stripVersions>
+      <!--<stripVersions>false</stripVersions>-->
 
       <!--
         (Optional) Setup custom java_location entries (see getdown documentation


### PR DESCRIPTION
The comments needed help, and I'm pretty sure there is no 1.0-SNAPSHOT on Maven Central; please correct me if I'm wrong.

I still can't get it to work, but here are some changes that might help it get closer to working.

When I try I get a 
``` [INFO] --- maven-install-plugin:2.4:install (default-install) @ getdownAttempt3 ---
[INFO] Installing C:\Users\BradTurek\IdeaProjects\Education\getdownAttempt3\target\getdownAttempt3-1.0-SNAPSHOT.jar to C:\Users\BradTurek\.m2\reposi
tory\tech\ugma\education\getdownAttempt3\1.0-SNAPSHOT\getdownAttempt3-1.0-SNAPSHOT.jar
[INFO] Installing C:\Users\BradTurek\IdeaProjects\Education\getdownAttempt3\pom.xml to C:\Users\BradTurek\.m2\repository\tech\ugma\education\getdown
Attempt3\1.0-SNAPSHOT\getdownAttempt3-1.0-SNAPSHOT.pom
[INFO]
[INFO] --- getdown-maven-plugin:0.3:build (default) @ getdownAttempt3 ---
Generating digest file 'C:\Users\BradTurek\IdeaProjects\Education\getdownAttempt3\target\digest.txt'...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.238 s
[INFO] Finished at: 2017-08-19T18:04:55-06:00
[INFO] Final Memory: 8M/21M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.digitalbarista:getdown-maven-plugin:0.3:build (default) on project getdownAttempt3: A type incompatibility occurr
ed while executing com.digitalbarista:getdown-maven-plugin:0.3:build: [Ljava.lang.String; cannot be cast to java.lang.String
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>com.digitalbarista:getdown-maven-plugin:0.3
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/C:/Users/BradTurek/.m2/repository/com/digitalbarista/getdown-maven-plugin/0.3/getdown-maven-plugin-0.3.jar
[ERROR] urls[1] = file:/C:/Users/BradTurek/.m2/repository/org/apache/maven/maven-builder-support/3.3.3/maven-builder-support-3.3.3.jar
[ERROR] urls[2] = file:/C:/Users/BradTurek/.m2/repository/com/google/guava/guava/18.0/guava-18.0.jar
[ERROR] urls[3] = file:/C:/Users/BradTurek/.m2/repository/javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar
[ERROR] urls[4] = file:/C:/Users/BradTurek/.m2/repository/javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar
[ERROR] urls[5] = file:/C:/Users/BradTurek/.m2/repository/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.0/org.eclipse.sisu.inject-0.3.0.jar
[ERROR] urls[6] = file:/C:/Users/BradTurek/.m2/repository/org/sonatype/sisu/sisu-guice/3.2.5/sisu-guice-3.2.5-no_aop.jar
[ERROR] urls[7] = file:/C:/Users/BradTurek/.m2/repository/aopalliance/aopalliance/1.0/aopalliance-1.0.jar
[ERROR] urls[8] = file:/C:/Users/BradTurek/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar
[ERROR] urls[9] = file:/C:/Users/BradTurek/.m2/repository/org/codehaus/plexus/plexus-utils/3.0.20/plexus-utils-3.0.20.jar
[ERROR] urls[10] = file:/C:/Users/BradTurek/.m2/repository/org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5
.jar
[ERROR] urls[11] = file:/C:/Users/BradTurek/.m2/repository/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar
[ERROR] urls[12] = file:/C:/Users/BradTurek/.m2/repository/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar
[ERROR] urls[13] = file:/C:/Users/BradTurek/.m2/repository/org/apache/maven/plugin-tools/maven-plugin-annotations/3.3/maven-plugin-annotations-3.3.j
ar
[ERROR] urls[14] = file:/C:/Users/BradTurek/.m2/repository/junit/junit/3.8.1/junit-3.8.1.jar
[ERROR] urls[15] = file:/C:/Users/BradTurek/.m2/repository/org/eclipse/aether/aether-util/1.0.0.v20140518/aether-util-1.0.0.v20140518.jar
[ERROR] urls[16] = file:/C:/Users/BradTurek/.m2/repository/com/threerings/getdown/1.6.3/getdown-1.6.3.jar
[ERROR] urls[17] = file:/C:/Program%20Files%20(x86)/Java/jdk1.8.0_131/jre/lib/plugin.jar
[ERROR] Number of foreign imports: 1
[ERROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
[ERROR]
[ERROR] -----------------------------------------------------
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
```