### PR TITLE
test: add basic integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.digitalbarista</groupId>
@@ -26,8 +26,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <organization>
@@ -53,6 +53,18 @@
             <name>Ivan Zemlyanskiy</name>
         </developer>
     </developers>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.7.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -90,6 +102,29 @@
             <artifactId>getdown</artifactId>
             <version>1.6.3</version>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.19.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.soebes.itf.jupiter.extension</groupId>
+            <artifactId>itf-assertj</artifactId>
+            <version>0.9.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.soebes.itf.jupiter.extension</groupId>
+            <artifactId>itf-jupiter-extension</artifactId>
+            <version>0.9.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <distributionManagement>
@@ -100,7 +135,50 @@
     </distributionManagement>
 
     <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>false</filtering>
+            </testResource>
+            <testResource>
+                <directory>src/test/resources-its</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <plugins>
+            <plugin>
+                <groupId>com.soebes.itf.jupiter.extension</groupId>
+                <artifactId>itf-maven-plugin</artifactId>
+                <version>0.9.0</version>
+                <executions>
+                    <execution>
+                        <id>installing</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>install</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M5</version>
+                <configuration>
+                    <!-- ! currently needed to run integration tests. -->
+                    <systemProperties>
+                        <maven.version>${maven.version}</maven.version>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemProperties>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>

--- a/src/test/java/com/dbi/getdown/plugin/it/FailureConditionsIT.java
+++ b/src/test/java/com/dbi/getdown/plugin/it/FailureConditionsIT.java
@@ -1,0 +1,20 @@
+package com.dbi.getdown.plugin.it;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.soebes.itf.jupiter.extension.MavenJupiterExtension;
+import com.soebes.itf.jupiter.extension.MavenTest;
+import com.soebes.itf.jupiter.maven.MavenExecutionResult;
+
+@MavenJupiterExtension
+public class FailureConditionsIT {
+
+    @MavenTest
+    public void no_class(MavenExecutionResult result) {
+        assertThat(result.isSuccesful()).as("isSuccessful").isFalse();
+        assertThat(result.isFailure()).as("isFailure").isTrue();
+        assertThat(result.isError()).as("isError").isFalse();
+        assertThat(contentOf(result.getMavenLog().getStdout().toFile())).contains("Caused by: java.io.IOException: m.missing_class");
+    }
+
+}

--- a/src/test/java/com/dbi/getdown/plugin/it/MimimalGetdownTxtIT.java
+++ b/src/test/java/com/dbi/getdown/plugin/it/MimimalGetdownTxtIT.java
@@ -1,0 +1,22 @@
+package com.dbi.getdown.plugin.it;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.File;
+
+import com.soebes.itf.jupiter.extension.MavenJupiterExtension;
+import com.soebes.itf.jupiter.extension.MavenTest;
+import com.soebes.itf.jupiter.maven.MavenExecutionResult;
+
+@MavenJupiterExtension
+public class MimimalGetdownTxtIT {
+
+    @MavenTest
+    public void minimal(MavenExecutionResult result) {
+        assertThat(result.isSuccesful()).as("isSuccessful").isTrue();
+        assertThat(result.isFailure()).as("isFailure").isFalse();
+        assertThat(result.isError()).as("isError").isFalse();
+        File getdowntxt = new File(result.getMavenProjectResult().getBaseDir(), "target/getdown.txt");
+        assertThat(getdowntxt).exists().hasSameTextualContentAs(new File(result.getMavenProjectResult().getBaseDir(), "expected/getdown.txt"));
+    }
+}

--- a/src/test/resources-its/com/dbi/getdown/plugin/it/FailureConditionsIT/no_class/pom.xml
+++ b/src/test/resources-its/com/dbi/getdown/plugin/it/FailureConditionsIT/no_class/pom.xml
@@ -1,0 +1,51 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>getdown-maven-plugin-it_test</artifactId>
+    <version>0.1-SNAPSHOT</version>
+
+    <name>Integration Test for getdown-maven-plugin</name>
+
+    <licenses>
+        <license>
+            <name>GNU General Public License (GPL)</name>
+            <url>http://www.gnu.org/licenses/gpl.txt</url>
+        </license>
+    </licenses>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.digitalbarista</groupId>
+                <artifactId>getdown-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <!-- A reference to a base getdown.txt file in your project -->
+                    <configFile>src/main/configs/getdown.txt</configFile>
+                    <!-- A list of additional properties that should appear in the getdown.txt -->
+                    <configProps>
+                        <appbase>http://www.mycompany.com/software/myApp/</appbase>
+                        <ui.name>My App - Play it and enjoy!</ui.name>
+                    </configProps>
+                    <!-- Set stripVersions to true if you want the versions removed from the jar file names, so that getdown does not leave a trail of jar versions behind -->
+                    <stripVersions>false</stripVersions>
+
+                    <!-- (Optional) Setup custom java_location entries (see getdown documentation for details). Per-platform example: <jvmLocations> <jvmLocation> <platform>windows</platform> 
+                        <path>/jvm/jvm-windows.jar</path> </jvmLocation> <jvmLocation> <platform>linux</platform> <path>/jvm/jvm-linux.jar</path> </jvmLocation> </jvmLocations> Single platform example: <jvmLocations> 
+                        <jvmLocation> <path>/jvm/jvm.jar</path> </jvmLocation> </jvmLocations> -->
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+    

--- a/src/test/resources-its/com/dbi/getdown/plugin/it/MimimalGetdownTxtIT/minimal/expected/getdown.txt
+++ b/src/test/resources-its/com/dbi/getdown/plugin/it/MimimalGetdownTxtIT/minimal/expected/getdown.txt
@@ -1,0 +1,4 @@
+class = does.not.exist.MainApp
+appbase = http://www.mycompany.com/software/myApp/
+ui.name = My App - Play it and enjoy!
+code = bin/getdown-maven-plugin-it_test-0.1-SNAPSHOT.jar

--- a/src/test/resources-its/com/dbi/getdown/plugin/it/MimimalGetdownTxtIT/minimal/pom.xml
+++ b/src/test/resources-its/com/dbi/getdown/plugin/it/MimimalGetdownTxtIT/minimal/pom.xml
@@ -1,0 +1,51 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>getdown-maven-plugin-it_test</artifactId>
+    <version>0.1-SNAPSHOT</version>
+
+    <name>Integration Test for getdown-maven-plugin</name>
+
+    <licenses>
+        <license>
+            <name>GNU General Public License (GPL)</name>
+            <url>http://www.gnu.org/licenses/gpl.txt</url>
+        </license>
+    </licenses>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.digitalbarista</groupId>
+                <artifactId>getdown-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <!-- A reference to a base getdown.txt file in your project -->
+                    <configFile>src/main/configs/getdown.txt</configFile>
+                    <!-- A list of additional properties that should appear in the getdown.txt -->
+                    <configProps>
+                        <appbase>http://www.mycompany.com/software/myApp/</appbase>
+                        <ui.name>My App - Play it and enjoy!</ui.name>
+                    </configProps>
+                    <!-- Set stripVersions to true if you want the versions removed from the jar file names, so that getdown does not leave a trail of jar versions behind -->
+                    <stripVersions>false</stripVersions>
+
+                    <!-- (Optional) Setup custom java_location entries (see getdown documentation for details). Per-platform example: <jvmLocations> <jvmLocation> <platform>windows</platform> 
+                        <path>/jvm/jvm-windows.jar</path> </jvmLocation> <jvmLocation> <platform>linux</platform> <path>/jvm/jvm-linux.jar</path> </jvmLocation> </jvmLocations> Single platform example: <jvmLocations> 
+                        <jvmLocation> <path>/jvm/jvm.jar</path> </jvmLocation> </jvmLocations> -->
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+    

--- a/src/test/resources-its/com/dbi/getdown/plugin/it/MimimalGetdownTxtIT/minimal/src/main/configs/getdown.txt
+++ b/src/test/resources-its/com/dbi/getdown/plugin/it/MimimalGetdownTxtIT/minimal/src/main/configs/getdown.txt
@@ -1,0 +1,1 @@
+class = does.not.exist.MainApp


### PR DESCRIPTION
Use itf-maven-plugin to create integration test that invoke getdown-maven-plugin.

FailureConditionsIT has an empty getdown.txt which causes getdown to thrown "m.missing_class" exceptions.

MimimalGetdownTxtIT only contains the class and compares it against the expected/getdown.txt which also contains the values specified in the configuration section of getdown-maven-plugin for the integration test pom.xml
